### PR TITLE
feat(startproject): add support to indicate Godot project directory.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,7 +118,7 @@ dependencies = [
  "capitalize",
  "clap",
  "heck",
- "path-calculate",
+ "relative-path",
 ]
 
 [[package]]
@@ -134,43 +134,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
-name = "once_cell"
-version = "1.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-
-[[package]]
 name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
-
-[[package]]
-name = "path-absolutize"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4af381fe79fa195b4909485d99f73a80792331df0625188e707854f0b3383f5"
-dependencies = [
- "path-dedot",
-]
-
-[[package]]
-name = "path-calculate"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4690055139867a4a0d11d18ab98d80b325d7aa573b99e0ae8e1bc787a4282da7"
-dependencies = [
- "path-absolutize",
-]
-
-[[package]]
-name = "path-dedot"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07ba0ad7e047712414213ff67533e6dd477af0a4e1d14fb52343e53d30ea9397"
-dependencies = [
- "once_cell",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -188,6 +155,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "relative-path"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bca40a312222d8ba74837cb474edef44b37f561da5f773981007a10bbaa992b0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,7 @@ dependencies = [
  "capitalize",
  "clap",
  "heck",
+ "path-calculate",
 ]
 
 [[package]]
@@ -133,10 +134,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "path-absolutize"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4af381fe79fa195b4909485d99f73a80792331df0625188e707854f0b3383f5"
+dependencies = [
+ "path-dedot",
+]
+
+[[package]]
+name = "path-calculate"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4690055139867a4a0d11d18ab98d80b325d7aa573b99e0ae8e1bc787a4282da7"
+dependencies = [
+ "path-absolutize",
+]
+
+[[package]]
+name = "path-dedot"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07ba0ad7e047712414213ff67533e6dd477af0a4e1d14fb52343e53d30ea9397"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ clap = { version = "4.5.32", features = ["derive"] }
 heck = "0.5.0"
 anyhow = "1.0.97"
 capitalize = "0.3.4"
+path-calculate = "0.1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ clap = { version = "4.5.32", features = ["derive"] }
 heck = "0.5.0"
 anyhow = "1.0.97"
 capitalize = "0.3.4"
-path-calculate = "0.1.3"
+relative-path = "2.0.1"

--- a/README.md
+++ b/README.md
@@ -76,6 +76,15 @@ gdext-cli startproject example-game example-game-name
 ```
 This will create the necessary directories and files for a new Godot-Rust project.
 
+You can indicate your godot project directory by using the `--godot-dir` option:
+
+```bash
+# pwd -> ~/game_example/rust/
+gdext-cli startproject --godot-dir ../godot example-game example-game-name
+```
+
+Keep in mind the Godot project directory must exist previous to executing this command.
+
 ### Create a new script
 
 ```bash
@@ -100,6 +109,22 @@ SUBCOMMANDS:
     startproject    Initialize a new Godot-Rust project
     script           Generate a new script with the given name and node type
     help            Print this message or the help of the given subcommand(s)
+```
+
+### Start Project Command
+
+```
+Initialize a new Godot-Rust project
+
+Usage: gdext-cli startproject [OPTIONS] <SCRIPT> <NAME>
+
+Arguments:
+  <SCRIPT>  
+  <NAME>    
+
+Options:
+      --godot-dir <GODOT_DIR>  The path to the Godot project directory
+  -h, --help                   Print help
 ```
 
 ### Script Command

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ enum Commands {
     Startproject {
         script: String,
         name: String,
+        /// The path to the Godot project directory
         #[arg(long)]
         godot_dir: Option<PathBuf>,
     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 //third-party modules
 use anyhow::Result;
 use clap::{Parser, Subcommand};
@@ -10,12 +12,13 @@ mod startproject_gen;
 use template_gen::handle_template;
 mod template_gen;
 
-
 #[derive(Parser)]
 #[command(name = "gdext-cli")]
 #[command(about = "A CLI tool to generate Godot-Rust projects", long_about = None)]
 #[command(version)]
-#[command(author = "Frank Casanova\n<frankcasanova.info@gmail.com>\n<https://github.com/FrankCasanova>\n<https://linkedin.com/in/frankcasanova->")]
+#[command(
+    author = "Frank Casanova\n<frankcasanova.info@gmail.com>\n<https://github.com/FrankCasanova>\n<https://linkedin.com/in/frankcasanova->"
+)]
 struct Cli {
     #[command(subcommand)]
     command: Commands,
@@ -24,9 +27,11 @@ struct Cli {
 #[derive(Subcommand)]
 enum Commands {
     /// Initialize a new Godot-Rust project
-    Startproject{
+    Startproject {
         script: String,
         name: String,
+        #[arg(long)]
+        godot_dir: Option<PathBuf>,
     },
     /// Generate a new script with the given name and node type
     Script {
@@ -36,9 +41,7 @@ enum Commands {
         typenode: String,
     },
     /// Create a new project from a template
-    Template{
-        name: String,
-    },
+    Template { name: String },
 }
 
 /// The entry point of the CLI tool.
@@ -50,11 +53,12 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Startproject {script,name} => handle_startproject(&script, &name),
+        Commands::Startproject {
+            script,
+            name,
+            godot_dir,
+        } => handle_startproject(&script, &name, &godot_dir),
         Commands::Script { name, typenode } => handle_script(&name, &typenode),
-        Commands::Template {name } => handle_template(&name),
+        Commands::Template { name } => handle_template(&name),
     }
 }
-
-
-

--- a/src/startproject_gen.rs
+++ b/src/startproject_gen.rs
@@ -1,70 +1,108 @@
 //third-party modules
 use anyhow::Result;
-use std::fs;
 use capitalize::Capitalize;
+use path_calculate::Calculate;
+use std::{env, fs, path::PathBuf};
 
-    /// Initializes a new Godot-Rust project.
-    ///
-    /// # Description
-    ///
-    /// This function creates a new Godot-Rust project by creating the necessary
-    /// directories and files, including `src/lib.rs`, `rust.gdextension`, and
-    /// `Cargo.toml`. The project name is inferred from the current directory
-    /// name.
-    ///
-    /// # Errors
-    ///
-    /// If the project directory already exists, this function will return an
-    /// error. If the files cannot be created, this function will return an
-    /// error. If the `godot-rust` crate cannot be found, this function will
-    /// return an error.
-pub fn handle_startproject(script: &str, name: &str) -> Result<()> {
+/// Initializes a new Godot-Rust project.
+///
+/// # Description
+///
+/// This function creates a new Godot-Rust project by creating the necessary
+/// directories and files, including `src/lib.rs`, `rust.gdextension`, and
+/// `Cargo.toml`. The project name is inferred from the current directory
+/// name.
+///
+/// # Errors
+///
+/// If the project directory already exists, this function will return an
+/// error. If the files cannot be created, this function will return an
+/// error. If the `godot-rust` crate cannot be found, this function will
+/// return an error.
+pub fn handle_startproject(script: &str, name: &str, godot_dir: &Option<PathBuf>) -> Result<()> {
     // Create src directory
     fs::create_dir_all("src")?;
 
+    // Setup directories
+    let cwd = env::current_dir()?;
+    let gdextension_filename = "rust.gdextension";
+    let godot_project_dir = godot_dir.as_ref().map(|p| p.as_path()).unwrap_or(&cwd);
+
+    // Use current working directory to build a relative path to godot project directory
+    let binding = cwd.related_to(godot_project_dir)?;
+    let gdextension_root = binding.to_str().unwrap();
+
+    let mut gdextension_path = godot_project_dir.to_path_buf();
+    gdextension_path.push(gdextension_filename);
+
     // Create lib.rs
+    let lib_rs = generate_lib_rs(script);
+    fs::write("src/lib.rs", lib_rs)?;
+
+    // Create rust.gdextension
+    let gdextension_content: String = generate_gdextension(name, gdextension_root);
+    fs::write(gdextension_path, gdextension_content)?;
+
+    // Create Cargo.toml
+    let cargo_toml = generate_cargo_toml_file(name);
+    fs::write("Cargo.toml", cargo_toml)?;
+
+    Ok(())
+}
+
+fn generate_lib_rs(script: &str) -> String {
+    // Convert the script name from kebab-case to PascalCase
     let script_words: Vec<&str> = script.split('-').collect();
     let script = script_words
         .iter()
-        .map(|word| 
-            word.capitalize())
-                .collect::<Vec<String>>()
-                .join("");
-    let lib_rs = format!(r#"use godot::prelude::*;
+        .map(|word| word.capitalize())
+        .collect::<Vec<String>>()
+        .join("");
+
+    format!(
+        r#"use godot::prelude::*;
 
 struct {script};
 
 #[gdextension]
-unsafe impl ExtensionLibrary for {script} {{}}"#, script = script);
+unsafe impl ExtensionLibrary for {script} {{}}"#
+    )
+}
 
-    fs::write("src/lib.rs", lib_rs)?;
-
+fn generate_gdextension(name: &str, godot_project_root: &str) -> String {
     // Create rust.gdextension
     let name_snake_case = &name.to_lowercase();
     let name_snake_case = &name_snake_case.replace("-", "_");
-    let gdextension: String= format!(r#"[configuration]
+    let rust_target_path: PathBuf = [godot_project_root, "target"].iter().collect();
+
+    format!(
+        r#"[configuration]
 entry_symbol = "gdext_rust_init"
 compatibility_minimum = 4.3
 reloadable = true
 
 [libraries]
-linux.debug.x86_64 = "res://../../target/debug/lib{name}.so"
-linux.release.x86_64 = "res://../../target/release/lib{name}.so"
-windows.debug.x86_64 = "res://../../target/debug/{name}.dll"
-windows.release.x86_64 = "res://../../target/release/{name}.dll"
-macos.debug = "res://../../target/debug/lib{name}.dylib"
-macos.release = "res://../../target/release/lib{name}.dylib"
-macos.debug.arm64 = "res://../../target/debug/lib{name}.dylib"
-macos.release.arm64 = "res://../../target/release/lib{name}.dylib"
-web.debug.wasm32 = "res://../../target/wasm32-unknown-emscripten/debug/{name}.wasm"
-web.release.wasm32 = "res://../../target/wasm32-unknown-emscripten/release/{name}.wasm"
-"#, name = name_snake_case);
-    fs::write("rust.gdextension", gdextension)?;
+linux.debug.x86_64 = "res://{rust_project}/debug/lib{name}.so"
+linux.release.x86_64 = "res://{rust_project}/release/lib{name}.so"
+windows.debug.x86_64 = "res://{rust_project}/debug/{name}.dll"
+windows.release.x86_64 = "res://{rust_project}/release/{name}.dll"
+macos.debug = "res://{rust_project}/debug/lib{name}.dylib"
+macos.release = "res://{rust_project}/release/lib{name}.dylib"
+macos.debug.arm64 = "res://{rust_project}/debug/lib{name}.dylib"
+macos.release.arm64 = "res://{rust_project}/release/lib{name}.dylib"
+web.debug.wasm32 = "res://{rust_project}/wasm32-unknown-emscripten/debug/{name}.wasm"
+web.release.wasm32 = "res://{rust_project}/wasm32-unknown-emscripten/release/{name}.wasm"
+"#,
+        name = name_snake_case,
+        rust_project = rust_target_path.to_str().unwrap(),
+    )
+}
 
-    // Create Cargo.toml
+fn generate_cargo_toml_file(name: &str) -> String {
     let name_snake_case = &name.to_lowercase();
     let name_snake_case = &name_snake_case.replace("-", "_");
-    let cargo_toml: String = format!(r#"[package]
+    format!(
+        r#"[package]
 name = "{name}"
 version = "0.1.0"
 edition = "2024"
@@ -74,8 +112,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 godot = {{ git = "https://github.com/godot-rust/gdext.git", branch = "master" }}
-"#, name = name_snake_case);
-    fs::write("Cargo.toml", cargo_toml)?;
-
-    Ok(())
+"#,
+        name = name_snake_case
+    )
 }

--- a/src/startproject_gen.rs
+++ b/src/startproject_gen.rs
@@ -26,18 +26,19 @@ pub fn handle_startproject(script: &str, name: &str, godot_dir: &Option<PathBuf>
     // Setup directories
     let cwd = env::current_dir()?;
     let gdextension_filename = "rust.gdextension";
-    
+
     // Handle godot_dir path with proper canonicalization
     let godot_project_dir = match godot_dir {
         Some(path) => path.canonicalize()?,
-        None => cwd.clone()
+        None => cwd.clone(),
     };
 
     // Calculate relative path from godot project to rust project
-    let gdextension_root = cwd.canonicalize()?
+    let gdextension_root = cwd
+        .canonicalize()?
         .relative_to(&godot_project_dir)?
         .into_string()
-        .replace('\\', "/"); // Normalize path separators
+        .replace(std::path::MAIN_SEPARATOR_STR, "/"); // Normalize path separators
 
     let gdextension_file = godot_project_dir.to_path_buf().join(gdextension_filename);
 

--- a/src/startproject_gen.rs
+++ b/src/startproject_gen.rs
@@ -74,6 +74,14 @@ fn generate_gdextension(name: &str, godot_project_root: &str) -> String {
     let name_snake_case = &name_snake_case.replace("-", "_");
     let rust_target_path: PathBuf = [godot_project_root, "target"].iter().collect();
 
+    // Sanitize OS-specific path
+    let rust_target_str = &rust_target_path
+        .to_str()
+        .unwrap()
+        .split(std::path::MAIN_SEPARATOR_STR)
+        .collect::<Vec<&str>>()
+        .join("/");
+
     format!(
         r#"[configuration]
 entry_symbol = "gdext_rust_init"
@@ -93,7 +101,7 @@ web.debug.wasm32 = "res://{rust_project}/wasm32-unknown-emscripten/debug/{name}.
 web.release.wasm32 = "res://{rust_project}/wasm32-unknown-emscripten/release/{name}.wasm"
 "#,
         name = name_snake_case,
-        rust_project = rust_target_path.to_str().unwrap(),
+        rust_project = rust_target_str,
     )
 }
 

--- a/src/template_gen.rs
+++ b/src/template_gen.rs
@@ -2,8 +2,8 @@
 use anyhow::Result;
 
 //own modules
-use crate::startproject_gen::handle_startproject;
 use crate::script_gen::handle_script;
+use crate::startproject_gen::handle_startproject;
 
 /// Creates a new project from a template.
 ///
@@ -19,7 +19,7 @@ use crate::script_gen::handle_script;
 /// error. If the `godot-rust` crate cannot be found, this function will
 /// return an error.
 pub fn handle_template(name: &str) -> Result<()> {
-    handle_startproject(name, name)?;
+    handle_startproject(name, name, &None)?;
     handle_script("player", "character-body-2d")?;
     Ok(())
 }


### PR DESCRIPTION
Add `--godot-dir` option on `startproject` command to specify the Godot project directory where the `.gdextension` file will be saved. It's useful in case you want to separate your Godot project from the Rust project. It also specifies the libraries paths as well so this doesn't need to be tweaked by the user.

Usage:

```bash
# pwd -> ~/my-new-project/rust
gdext-cli startproject --godot-dir ../godot example-game example-game-name